### PR TITLE
need superfences to render multiline code blocks correctly

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ plugins:
 markdown_extensions:
   - attr_list
   - md_in_html
+  - pymdownx.superfences
 copyright: Copyright &copy; 2024 AllStarLink Inc.
 theme:
   name: material


### PR DESCRIPTION
The `nmcli` commands at the bottom of the cockpit-network page were being smashed into one line, creating confusion on the correct command to use.

The original markdown spec doesn't render multiline code blocks. We need the superfences plugin in order for it to render correctly. 

Closes https://github.com/AllStarLink/ASL3/issues/84