### PR TITLE
Add index.md page for the Advanced Topics section, re-org ToC.

### DIFF
--- a/docs/adv-topics/index.md
+++ b/docs/adv-topics/index.md
@@ -2,6 +2,6 @@
 
 Welcome to the Advanced Topics section of the ASL3 Manual.
 
-Here, you will find information on how to configure a number of the different features that ASL3 has to offer. You will also find further detailed information on how some things in ASL3 operate "under the hood", if you are looking for more in depth explanations.
+Here, you will find information on how to configure a number of the different features that ASL3 has to offer. If you are interested, you will also find some information here that provides more in-depth explanations on how things in ASL3 operate "under the hood".
 
-As you may be aware, there are differences in the the way ASL3 operates, compared to previous versions. Please be sure to review the [New Commands](./commands.md) amd [Incompatibilities, Changes, and Known Issues](./incompatibles.md) pages to be aware of these changes.
+As you may be aware, there are differences in the the way ASL3 operates compared to previous versions. Please be sure to review the [New Commands](./commands.md) amd [Incompatibilities, Changes, and Known Issues](./incompatibles.md) pages to be aware of these changes.

--- a/docs/adv-topics/index.md
+++ b/docs/adv-topics/index.md
@@ -1,0 +1,7 @@
+# Advanced Topics
+
+Welcome to the Advanced Topics section of the ASL3 Manual.
+
+Here, you will find information on how to configure a number of the different features that ASL3 has to offer. You will also find further detailed information on how some things in ASL3 operate "under the hood", if you are looking for more in depth explanations.
+
+As you may be aware, there are differences in the the way ASL3 operates, compared to previous versions. Please be sure to review the [New Commands](./commands.md) amd [Incompatibilities, Changes, and Known Issues](./incompatibles.md) pages to be aware of these changes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,30 +85,31 @@ nav:
       - pi/cockpit-services.md
       - pi/cockpit-firewall.md
   - Advanced Topics:
+    - adv-topics/index.md
     - adv-topics/commands.md
     - adv-topics/incompatibles.md
-    - adv-topics/noderesolution.md
+    - adv-topics/allowdenylists.md
+    - adv-topics/aprs.md
+    - adv-topics/tts.md 
+    - adv-topics/conftmpl.md
+    - adv-topics/autopatch.md
+    - adv-topics/audio-level.md
+    - adv-topics/daq.md
+    - adv-topics/hotspot_hd.md
     - adv-topics/httpreg.md
     - adv-topics/iaxreg.md
-    - adv-topics/usbinterfaces.md
-    - adv-topics/audio-level.md
+    - adv-topics/litz.md
+    - adv-topics/multinodesnetwork.md 
+    - adv-topics/noderesolution.md
+    - adv-topics/other-software.md
+    - adv-topics/permissions.md
     - adv-topics/sa818modules.md
-    - adv-topics/conftmpl.md
-    - adv-topics/allowdenylists.md
     - adv-topics/sip-phone.md
     - adv-topics/broadcastify.md
-    - adv-topics/hotspot_hd.md
-    - adv-topics/autopatch.md
-    - adv-topics/permissions.md
-    - adv-topics/uefi-secureboot.md
-    - adv-topics/tts.md  
-    - adv-topics/multinodesnetwork.md  
-    - adv-topics/aprs.md
-    - adv-topics/daq.md
-    - adv-topics/litz.md
     - adv-topics/remotebase.md
     - adv-topics/rxtoneburst.md
-    - adv-topics/other-software.md
+    - adv-topics/uefi-secureboot.md
+    - adv-topics/usbinterfaces.md
   - Developer Guide:
     - developers/package-builds.md
     - developers/source-install.md


### PR DESCRIPTION
Added an `index.md` landing page for the Advanced Topics section.

Re-organized the Table of Contents to alphabetize the sections, except for New Commands and Incompatibilities, which should be the first sections to review, before getting into anything else.