### PR TITLE
Create an index.md for the Developer section of the manual.

### DIFF
--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -1,0 +1,5 @@
+# Developer Guide
+
+The pages in this section are geared towards ASL3 developers. 
+
+It contains information on how packages/releases are built and managed from the [GitHub Repository](https://github.com/AllStarLink), as well as information on building ASL3 from source.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,7 @@ nav:
     - adv-topics/rxtoneburst.md
     - adv-topics/other-software.md
   - Developer Guide:
+    - developers/index.md
     - developers/package-builds.md
     - developers/source-install.md
     - developers/aptly.md


### PR DESCRIPTION
Adding an `index.md` landing page for the Developer section of the manual.