### PR TITLE
Add index.md for the Mans section of the manual

### DIFF
--- a/docs/mans/index.md
+++ b/docs/mans/index.md
@@ -3,3 +3,11 @@
 This section of the manual contains the Manual Pages with detailed information for the utilities included with with ASL3.
 
 The Manual Pages for each utility describe what the utility does, the available options it supports, and sample usage.
+
+Manual Pages are also installed on your Linux system when the utility is installed. You can the built-in Linux `man` pages facility to get help on these utilities from the Linux CLI.
+
+Example:
+
+```
+man asl-find-sound
+```

--- a/docs/mans/index.md
+++ b/docs/mans/index.md
@@ -1,0 +1,5 @@
+# Man Pages
+
+This section of the manual contains the Manual Pages with detailed information for the utilities included with with ASL3.
+
+The Manual Pages for each utility describe what the utility does, the available options it supports, and sample usage.

--- a/docs/mans/index.md
+++ b/docs/mans/index.md
@@ -4,7 +4,7 @@ This section of the manual contains the Manual Pages with detailed information f
 
 The Manual Pages for each utility describe what the utility does, the available options it supports, and sample usage.
 
-Manual Pages are also installed on your Linux system when the utility is installed. You can the built-in Linux `man` pages facility to get help on these utilities from the Linux CLI.
+Manual Pages are also installed on your Linux system when the utility is installed. You can view the built-in Linux `man` pages facility to get help on these utilities from the Linux CLI.
 
 Example:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,11 +114,12 @@ nav:
     - developers/source-install.md
     - developers/aptly.md
   - Man Pages:
-      - mans/asl-find-sound.md
-      - mans/asl-node-lookup.md
-      - mans/asl-play-arn.md
-      - mans/asl-say.md
-      - mans/asl-setup-dkms-mok.md
+    - mans/index.md
+    - mans/asl-find-sound.md
+    - mans/asl-node-lookup.md
+    - mans/asl-play-arn.md
+    - mans/asl-say.md
+    - mans/asl-setup-dkms-mok.md
   - Config Files:
     - config/config-structure.md
     - config/rpt_conf.md


### PR DESCRIPTION
Adding an `index.md` landing page for the Manual Pages section.