### PR TITLE
Add index.md for Config Files section.

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -1,0 +1,5 @@
+# Config Files
+
+This section of the manual provides in in-depth look at all the configuration files related to ASL3.
+
+Information provided includes how the file is structured, the available/supported options, a description of the supported options, and what the default values of each option is (if applicable).

--- a/docs/config/rpt_conf.md
+++ b/docs/config/rpt_conf.md
@@ -1,4 +1,4 @@
-# Rpt.conf
+# rpt.conf
 Rpt.conf (`/etc/asterisk/rpt.conf`) is where the majority of user-facing features, such as the node's CW and voice ID, DTMF commands and timers are set. There is a lot of capability here which can be difficult to grasp. Fortunately the default `rpt.conf` is well commented and will work fine for most node admins.
 
 See also [config file templating](../adv-topics/conftmpl.md/#asterisk-templates).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -120,5 +120,6 @@ nav:
       - mans/asl-say.md
       - mans/asl-setup-dkms-mok.md
   - Config Files:
+    - config/index.md
     - config/config-structure.md
     - config/rpt_conf.md


### PR DESCRIPTION
Add an `index.md` landing page for the Config Files section of the manual.