### PR TITLE
Convert Macro Use and Format Wiki page for ASL3 manual

### DIFF
--- a/docs/adv-topics/macros.md
+++ b/docs/adv-topics/macros.md
@@ -38,27 +38,17 @@ wait_times=wait_times
 telemetry=telemetry
 ```
 
-If you have more than one node on a given server and you want all nodes to have the same macros then the above `macro=macro` (or nothing defined) is fine. 
+If you have more than one node on a given server and you want all nodes to have the same macros, then the above `macro=macro` (or nothing defined) is fine. If you want to assign different macros to different nodes on the server, see the [Structure of Config Files](../config/config-structure.md#settings-to-name-other-stanzas) page which outlines how to redirect names to call other stanzas.
 
-However, you may want your nodes to have separate set of macros. In that case you need a separation for a specific node. In the settings for each node on the server, you can override the stanza name for that specific node. 
-
-Eaxmple:
+Then, later in `rpt.conf` you need an actual `[macro]` stanza:
 
 ```
-macro=macro12345                    ; Point to a [macro12345] stanza for this node
-```
-
-Then, later in `rpt.conf`:
-
-```
-[macro12345]
+[macro]
 1=*81#                              ; Say time
 2=*81 P *31999 P *934#              ; Say time, pause, connect node 1999, pause, and turn off telemetry for net
 3=*31999 *934 *512#                 ; Here we connect node 1999, turn off telemetry, then call macro (12). 
 12=*949#                            ; Disable incoming connections
 ```
-
-See [Settings to Name Other Stanzas](../config/config-structure.md#settings-to-name-other-stanzas) for more information.
 
 ## Macro Definitions
 Finally, define each desired macro in the appropriate `[macro]` stanza.
@@ -69,9 +59,15 @@ A `P` can be used to cause a pause of 500mS, or a series of them for more. This 
 
 Looking at the above example, you can see how multiple DTMF commands can be chained together into a single macro, so that you wouldn't have to execute the commands individually.
 
-And note that use of our macro 2 (executed as `*52`) might also require us to create a new one to 'undo' any of our changes. Which in this case, might be manually called at the end of the net.
+And note that use of our macro 2 (executed as `*52`) might also require us to create a new one to 'undo' any of our changes. Which, in this case, might be manually called at the end of the net.
+
+Example:
+
+```
+4=*11999 P *933#                    ; End of net macro, unlink from node 1999 and turn telemetry back on
+```
 
 # Scheduler Execution
-With the example configuration shown, macros are called with a `*5` prefix, and followed with the number assigned in the [macro] stanza.
+With the example configuration shown, macros are called with a `*5` prefix and followed with the number assigned in the [macro] stanza.
 
 You can also call them from the system schedular by number. Calling a macro number is the only method the scheduler supports. So if you wish to schedule with the system scheduler, you need a macro to execute it.

--- a/docs/adv-topics/macros.md
+++ b/docs/adv-topics/macros.md
@@ -1,0 +1,77 @@
+# Macros
+
+## What is a 'macro'?
+The purpose of a macro is to store a sequence of DTMF command(s). Macros may be called by direct command, by the system scheduler, or even by an external script. They can be a series of commands to make short work of a larger task.
+
+## Define Function
+The first thing to configure when setting up macros is to define the [`[function]`](../config/rpt_conf.md#functions) that will call them.
+
+This will define the DTMF prefix that will be used for calling macros.
+
+Example:
+
+```
+[functions]
+5 = macro
+```
+
+This will make `5` the prefix for calling a macro. Remember that the actual command needs to be prefixed with [`funcchar`](../config/rpt_conf.md#funcchar), which is typically `*`. So in this case, `*512` would call macro 12 (defined in the `[macro]` stanza). 
+
+## Configuring Macro Stanzas
+The next part of macro settings is the [`macro=`](../config/rpt_conf.md#macro) setting in [`rpt.conf`](../config/rpt_conf.md). The example here points to a stanza named `[macro]`. This is likely already in your config. If the `macro=` setting does not exist, the default is to use a stanza named `[macro]`.  
+
+```
+[1999]                              ; Assigned node number
+rxchannel = SimpleUSB/1999	        ; Rx audio/signaling channel
+duplex=2
+linktolink=no
+controlstates=controlstates         ; System control state list
+scheduler=scheduler
+events=events
+morse=morse
+macro=macro                         ; <===== note this in your rpt.conf, if it exists
+tonemacro=tonemacro
+functions=functions
+phone_functions=phone_functions
+link_functions=link_functions
+wait_times=wait_times
+telemetry=telemetry
+```
+
+If you have more than one node on a given server and you want all nodes to have the same macros then the above `macro=macro` (or nothing defined) is fine. 
+
+However, you may want your nodes to have separate set of macros. In that case you need a separation for a specific node. In the settings for each node on the server, you can override the stanza name for that specific node. 
+
+Eaxmple:
+
+```
+macro=macro12345                    ; Point to a [macro12345] stanza for this node
+```
+
+Then, later in `rpt.conf`:
+
+```
+[macro12345]
+1=*81#                              ; Say time
+2=*81 P *31999 P *934#              ; Say time, pause, connect node 1999, pause, and turn off telemetry for net
+3=*31999 *934 *512#                 ; Here we connect node 1999, turn off telemetry, then call macro (12). 
+12=*949#                            ; Disable incoming connections
+```
+
+See [Settings to Name Other Stanzas](../config/config-structure.md#settings-to-name-other-stanzas) for more information.
+
+## Macro Definitions
+Finally, define each desired macro in the appropriate `[macro]` stanza.
+
+Each macro command string is on the same line separated by a space, and ending the string with a `#` (hashtag). 
+
+A `P` can be used to cause a pause of 500mS, or a series of them for more. This would allow time for a script or connection to execute before the next command is issued. The system reads/executes them left to right when called. You should test them after creating them to be sure timing has no interference before you actually need to use them. 
+
+Looking at the above example, you can see how multiple DTMF commands can be chained together into a single macro, so that you wouldn't have to execute the commands individually.
+
+And note that use of our macro 2 (executed as `*52`) might also require us to create a new one to 'undo' any of our changes. Which in this case, might be manually called at the end of the net.
+
+# Scheduler Execution
+With the example configuration shown, macros are called with a `*5` prefix, and followed with the number assigned in the [macro] stanza.
+
+You can also call them from the system schedular by number. Calling a macro number is the only method the scheduler supports. So if you wish to schedule with the system scheduler, you need a macro to execute it.

--- a/docs/config/rpt_conf.md
+++ b/docs/config/rpt_conf.md
@@ -635,7 +635,7 @@ Sample:
 macro=macro   ; use stanza named macro
 
 [macro]
-1 = *32000*32001     ; connect to nodes 2000 and 2001
+1 = *32000 *32001#                  ; connect to nodes 2000 and 2001
 ```
 
 The default is to have `macro=` point to a stanza called `macro`, and have a common set of commands for all nodes. However, you can have it point to another named stanza, see [Settings to Name Other Stanzas](./config-structure.md#settings-to-name-other-stanzas) for more information.
@@ -1300,7 +1300,7 @@ macro=macro   ; use stanza named macros
 1 = *32000*32001     ; connect to nodes 2000 and 2001
 ```
 
-See [Full Macro Use And Format](https://wiki.allstarlink.org/index.php?title=Macro_use_and_format) for more information on macros.
+See the [Macro](../adv-topics/macros.md) page for more information on macros.
 
 ## Morse Stanza
 The `[morse]` stanza is a named stanza pointed to by the [`morse=](#morse) option.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,7 @@ nav:
     - adv-topics/httpreg.md
     - adv-topics/iaxreg.md
     - adv-topics/litz.md
+    - adv-topics/macros.md
     - adv-topics/multinodesnetwork.md 
     - adv-topics/noderesolution.md
     - adv-topics/other-software.md


### PR DESCRIPTION
Clean up and convert the Macro Use and Format Wiki page for inclusion in the ASL3 manual.