### PR TITLE
Add further documentation about connpgm and discpgm.

### DIFF
--- a/docs/adv-topics/condiscpgm.md
+++ b/docs/adv-topics/condiscpgm.md
@@ -10,10 +10,10 @@ Each node requiring this can have its own in that node's stanza. See [Asterisk T
 
 There is no requirement for using both `connpgm` and `discpgm`. Use the one you need, or both.
 
-Shell scripts need to be owned by `asterisk` and have the execution bit set. See the [Permissions](./permissions.md) page for more information.
+Shell scripts need to be readable and executable by `asterisk`. See the [Permissions](./permissions.md) page for more information.
 
 ## `connpgm`
-`connpgm` executes a program you specify on connect. It passes two command line arguments to your program:
+`connpgm` executes a program or script you specify on connect. It passes two command line arguments to your program/script:
 
 * node number in this stanza (us) as `$1`
 
@@ -34,7 +34,7 @@ connpgm = /etc/asterisk/custom/conlog.sh
 ```
 
 ## `discpgm`
-`discpgm` executes a program you specify on disconnect. It passes two command line arguments to your program:
+`discpgm` executes a program or script you specify on disconnect. It passes two command line arguments to your program/script:
 
 * node number in this stanza (us) as `$1`
 
@@ -53,4 +53,17 @@ Example configuration in `rpt.conf`:
 ```
 discpgm = /etc/asterisk/custom/dislog.sh
 ```
+
+## Execution and Passing Variables
+Asterisk uses `bash -c <connpgm-string> <my-node> <other-node> &` when it runs `connpgm` and `discpgm`. Using the `-c` option means that commands are read from the string (script) specified. If there are arguments after the string (script), they are assigned to the positional parameters, starting with `$0`.
+
+This means you can pass variables/commands to your script(s). 
+
+Sample:
+
+```
+connpgm=/etc/asterisk/custom/myscript 1
+discpgm=/etc/asterisk/custom/myscript 0
+```
+
 

--- a/docs/adv-topics/condiscpgm.md
+++ b/docs/adv-topics/condiscpgm.md
@@ -62,8 +62,8 @@ This means you can pass variables/commands to your script(s).
 Sample:
 
 ```
-connpgm=/etc/asterisk/custom/myscript 1
-discpgm=/etc/asterisk/custom/myscript 0
+connpgm=/etc/asterisk/custom/myscript abc 1234
 ```
 
+The above example would then execute `bash -c /etc/asterisk/custom/myscript abc 1234 <us> <them>` when a node connects. 
 

--- a/docs/adv-topics/condiscpgm.md
+++ b/docs/adv-topics/condiscpgm.md
@@ -1,0 +1,56 @@
+# Connect and Disconnect Scripts
+ASL3 supports a method to run a script or program when there is a node connecting or disconnecting.
+
+This is handled by the [`connpgm` and `discpgm`](../config/rpt_conf.md#connpgm-and-discpgm) directives in [`rpt.conf`](../config/rpt_conf.md).
+
+!!! warning "Every Connect/Disconnect"
+    Think your project through as this will run on **every connect or disconnect**. There is no way to limit it. However, your script could have a provision to ignore certain nodes or certain times.
+
+Each node requiring this can have its own in that node's stanza. See [Asterisk Templates](./conftmpl.md) for more information on how to apply this to individual node templates.
+
+There is no requirement for using both `connpgm` and `discpgm`. Use the one you need, or both.
+
+Shell scripts need to be owned by `asterisk` and have the execution bit set. See the [Permissions](./permissions.md) page for more information.
+
+## `connpgm`
+`connpgm` executes a program you specify on connect. It passes two command line arguments to your program:
+
+* node number in this stanza (us) as `$1`
+
+* node number being connected to us (them) as `$2`
+
+An example to log connections to the node (`conlog.sh`):
+
+```
+#!/bin/bash
+
+echo $1 connected $2  on $(date +"%T") - $(date +"%m-%d-%Y")  >> /var/www/html/nodelogs/conlog.txt
+```
+
+Example configuration in `rpt.conf`:
+
+```
+connpgm = /etc/asterisk/custom/conlog.sh
+```
+
+## `discpgm`
+`discpgm` executes a program you specify on disconnect. It passes two command line arguments to your program:
+
+* node number in this stanza (us) as `$1`
+
+* node number being connected to us (them) as `$2`
+
+An example to log disconnects from the node (`dislog.sh`):
+
+```
+#!/bin/bash
+
+echo $1 disconnected $2  on $(date +"%T") - $(date +"%m-%d-%Y")  >> /var/www/html/nodelogs/conlog.txt
+```
+
+Example configuration in `rpt.conf`:
+
+```
+discpgm = /etc/asterisk/custom/dislog.sh
+```
+

--- a/docs/adv-topics/condiscpgm.md
+++ b/docs/adv-topics/condiscpgm.md
@@ -13,11 +13,7 @@ There is no requirement for using both `connpgm` and `discpgm`. Use the one you 
 Shell scripts need to be readable and executable by `asterisk`. See the [Permissions](./permissions.md) page for more information.
 
 ## `connpgm`
-`connpgm` executes a program or script you specify on connect. It passes two command line arguments to your program/script:
-
-* node number in this stanza (us) as `$1`
-
-* node number being connected to us (them) as `$2`
+`connpgm` executes a program or script you specify on connect. 
 
 An example to log connections to the node (`conlog.sh`):
 
@@ -34,11 +30,7 @@ connpgm = /etc/asterisk/custom/conlog.sh
 ```
 
 ## `discpgm`
-`discpgm` executes a program or script you specify on disconnect. It passes two command line arguments to your program/script:
-
-* node number in this stanza (us) as `$1`
-
-* node number being connected to us (them) as `$2`
+`discpgm` executes a program or script you specify on disconnect.
 
 An example to log disconnects from the node (`dislog.sh`):
 
@@ -55,9 +47,11 @@ discpgm = /etc/asterisk/custom/dislog.sh
 ```
 
 ## Execution and Passing Variables
-Asterisk uses `bash -c <connpgm-string> <my-node> <other-node> &` when it runs `connpgm` and `discpgm`. Using the `-c` option means that commands are read from the string (script) specified. If there are arguments after the string (script), they are assigned to the positional parameters, starting with `$0`.
+Asterisk uses `bash -c <connpgm-string> <us> <them> &` when it runs `connpgm` and `discpgm`. Using the `-c` option means that commands are read from the string (script) specified. If there are arguments after the string (script), they are assigned to the positional parameters, starting with `$0` (search the Internet for "Bash positional arguments").
 
-This means you can pass variables/commands to your script(s). 
+As noted above, `app_rpt` adds two additional variables to the end of the command string being executed, `<node number in this stanza>` (us) and `<node number being connected to us>` (them). You don't NEED to use these variables, but they are provided for your use if your script wants to do something with them. 
+
+This also means you can pass variables/arguments to your script(s), if desired. 
 
 Sample:
 

--- a/docs/config/rpt_conf.md
+++ b/docs/config/rpt_conf.md
@@ -292,11 +292,7 @@ These options run user defined scripts.
 
 `discpgm` executes a program or script you specify when a node disconnects.
 
-`app_rpt` passes two variables to your script when it is executed:
-
-* node number in this stanza (us) as `$1`
-
-* node number being connected to us (them) as `$2`
+`app_rpt` passes two variables to your program or script when it is executed. They are added at the very end of the command string that is executed, `<node number in this stanza>` (us) and `<node number being connected to us>` (them). You do not NEED to use them, but they are available for your use.
 
 Sample:
 

--- a/docs/config/rpt_conf.md
+++ b/docs/config/rpt_conf.md
@@ -288,9 +288,9 @@ callerid="Repeater" <0000000000>
 ### connpgm= and discpgm=
 These options run user defined scripts.
 
-`connpgm` executes a script you specify when a node connects.
+`connpgm` executes a program or script you specify when a node connects.
 
-`discpgm` executes a script you specify when a node disconnects.
+`discpgm` executes a program or script you specify when a node disconnects.
 
 `app_rpt` passes two variables to your script when it is executed:
 
@@ -306,16 +306,7 @@ discpgm = /etc/asterisk/custom/dislog.sh
 
 ```
 
-You can also pass variables/commands to your script(s):
-
-Sample:
-
-```
-connpgm=/etc/asterisk/custom/myscript 1
-discpgm=/etc/asterisk/custom/myscript 0
-```
-
-See the [Connect and Disconnect Scripts](../adv-topics/condiscpgm.md) page for further details.
+See the [Connect and Disconnect Scripts](../adv-topics/condiscpgm.md) page for further details and options.
 
 ### context=
 This setting directs the autopatch for the node to use a specific context in `extensions.conf` for outgoing autopatch calls. The default is to specify a context name of radio.

--- a/docs/config/rpt_conf.md
+++ b/docs/config/rpt_conf.md
@@ -288,23 +288,34 @@ callerid="Repeater" <0000000000>
 ### connpgm= and discpgm=
 These options run user defined scripts.
 
-`connpgm` executes a program you specify on connect. It passes 2 command line arguments to your program:
+`connpgm` executes a script you specify when a node connects.
 
-1. node number in this stanza (us)
-2. node number being connected to us (them)
+`discpgm` executes a script you specify when a node disconnects.
 
-`discpgm` executes a program you specify on disconnect. It passes 2 command line arguments to your program:
+`app_rpt` passes two variables to your script when it is executed:
 
-1. node number in this stanza (us)
-2. node number being connected to us (them)                         
+* node number in this stanza (us) as `$1`
+
+* node number being connected to us (them) as `$2`
 
 Sample:
 
 ```
-# Place these lines in rpt.conf for each node:
-#     connpgm=/etc/asterisk/custom/myscript 1
-#     discpgm=/etc/asterisk/custom/myscript 0
+connpgm = /etc/asterisk/custom/conlog.sh
+discpgm = /etc/asterisk/custom/dislog.sh
+
 ```
+
+You can also pass variables/commands to your script(s):
+
+Sample:
+
+```
+connpgm=/etc/asterisk/custom/myscript 1
+discpgm=/etc/asterisk/custom/myscript 0
+```
+
+See the [Connect and Disconnect Scripts](../adv-topics/condiscpgm.md) page for further details.
 
 ### context=
 This setting directs the autopatch for the node to use a specific context in `extensions.conf` for outgoing autopatch calls. The default is to specify a context name of radio.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,7 @@ nav:
     - adv-topics/conftmpl.md
     - adv-topics/autopatch.md
     - adv-topics/audio-level.md
+    - adv-topics/condiscpgm.md
     - adv-topics/daq.md
     - adv-topics/dns-servers.md
     - adv-topics/eurorptr.md


### PR DESCRIPTION
Clean up the formatting for `connpgm` and `discpgm` in `rpt.conf`, an create an Advanced Topics page for them with a simple example from the Community.

Closes #47 