### PR TITLE
Document mdclog option in rpt.conf.

### DIFF
--- a/docs/adv-topics/mdc1200.md
+++ b/docs/adv-topics/mdc1200.md
@@ -1,6 +1,17 @@
 # MDC-1200 Signalling
 [MDC-1200](https://en.wikipedia.org/wiki/MDC-1200) signalling support is available in ASL3. MDC-1200 signalling could be used to have the node perform certain functions when a MDC-1200 code is received, and/or it can be used to signal user radios that have been configured for MDC-1200 signalling support.
 
+## MDC-1200 Logging
+A simple log for all local MDC-1200 Signalling received by the node is available by setting the [`mdclog=`](../config/rpt_conf.md#mdclog) option in [`rpt.conf`](../config/rpt_conf.md). When set, each incoming MDC-1200 burst that is decoded will be logged into the log file with a timestamp.
+
+Sample:
+
+```
+mdclog = /tmp/mdclog                ; log MDC-1200 received data to /tmp/mdclog
+```
+
+The directory you use needs to be writable by Asterisk. See the [Permissions](../adv-topics/permissions.md) page for more information.
+
 ## MDC-1200 Decoding Display
 On the [Asterisk CLI](../user-guide/menu.md#asterisk-cli) when MDC-1200 is received, the following will be displayed:
 

--- a/docs/config/rpt_conf.md
+++ b/docs/config/rpt_conf.md
@@ -710,6 +710,21 @@ The default is to have `macro=` point to a stanza called `macro`, and have a com
 
 See the [Macro Stanza](#macro-stanza) for more detail on defining macros.
 
+### mdclog=
+This option is used to enable a simple log for all local MDC-1200 Signalling received by the node. When set, each incoming MDC-1200 burst that is decoded will be logged into the log file with a timestamp.
+
+Sample:
+
+```
+mdclog = /tmp/mdclog                ; log MDC-1200 received data to /tmp/mdclog
+```
+
+The directory you use needs to be writable by Asterisk. See the [Permissions](../adv-topics/permissions.md) page for more information.
+
+See the [MDC-1200 Signalling](../adv-topics/mdc1200.md) page for more information on MDC-1200 support.
+
+**This option does not appear in the default `rpt.conf`.**
+
 ### morse=
 This option allows you to override the stanza name used for the `morse` stanza in `rpt.conf`. The morse stanza directs the node to use a particular stanza for morse code parameters for the node. Morse code parameters can be defined on a per-node basis.  
 


### PR DESCRIPTION
Document the currently "un-documented" `mdclog` option in `rpt.conf`.