### PR TITLE
Make top nav bar "stick" so it is always visible when scrolling.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ theme:
     - navigation.indexes
     - navigation.sections
     - navigation.tabs
+    - navigation.tabs.sticky
     - navigation.top
     - navigation.tracking
     - search.highlight


### PR DESCRIPTION
When scrolling down long pages (`rpt.conf`), the top nav bar disappears. This makes it cumbersome to flip between manual sections. Sticky navigation tabs resolves this so that the nav bar is always present (in full-window mode).