### PR TITLE
Fix autopatch dialtime description.

### DIFF
--- a/docs/adv-topics/autopatch.md
+++ b/docs/adv-topics/autopatch.md
@@ -144,7 +144,7 @@ There are several options that can be passed to the autopatchup command class. T
 | Option | Description |
 |------------------|-------------|
 | context | Override the context specified for the autopatch in `rpt.conf` |
-| dialtime | The maximum time to wait between DTMF digits when a telephone number is being dialed. The patch will automatically disconnect if this time is exceeded. The value is specified in milliseconds. |
+| dialtime | The maximum time to wait for DTMF digits to be received when a telephone number is being dialed. The patch will automatically disconnect/abort if this time is exceeded. The value is specified in milliseconds. |
 | farenddisconnect | When set to 1, the patch will automatically disconnect when the called party hangs up. The default is to send a circuit busy tone until the radio user brings the patch down. |
 | noct | When set to 1, the courtesy tone during an autopatch call will be disabled. The default is to send the courtesy tone whenever the radio user un-keys. |
 | quiet | When set to 1, do not send dial tone or voice responses, just try to connect the call. |


### PR DESCRIPTION
The existing description for `dialtime` is incorrect. It is not an "inter-digit" timer, it is the timer to wait for all digits to be received. If exceeded, the call aborts.

Reference:

https://github.com/AllStarLink/app_rpt/blob/f816be920331c5ae944415a1807a79e9bfae496d/apps/app_rpt.c#L1318C2-L1322C5

and

https://github.com/AllStarLink/app_rpt/blob/f816be920331c5ae944415a1807a79e9bfae496d/apps/app_rpt.c#L1334-L1340

(`dialtime` = `patchdialtime`, set in `rpt_functions.c`)

The inter-digit timer appears to actually be `calldigittimer`, but I haven't quite wrapped my head around how that works, and what the value actually is for that one.

This page needs additional work, but this is a quick correction.