### PR TITLE
Changes to reflect the upgraded "Node DB" --> "DNS" code

### DIFF
--- a/docs/adv-topics/dns-servers.md
+++ b/docs/adv-topics/dns-servers.md
@@ -63,19 +63,17 @@ dig TXT <nodenumber>.nodes.allstarlink.org
 will return:
 
 ```
-"NN=50000" "RT=2019-02-28 18:41:29" "RB=0" "IP=44.98.248.144" "PIP=" "PT=4569" "RH=register-west"
+"NN=50000" "IP=44.98.248.144" "PT=4569"
 ```
 
 Where:
 
-* NN is the node number
-* RT is the last update registration time
-* RB is 1 for node is not a remote base, RB is 0 if it is a remote base
-* IP is the IP address of the node
-* PIP is the proxy IP of the node if set
-* PT is the IAX port
-* RH is the registration server the node last registered to.
+* `NN` is the node number
+* `IP` is the IP address of the node
+* `PT` is the IAX port
 
+Note: earlier (pre Dec 2025) versions of the TXT record also included values for `RT` (last update registration time), `RB` (remote base), `PIP` (proxy IP), and `RH` (registration server).
+ 
 ## `asl-node-lookup`
 
 On ASL3 systems, the [`asl-node-lookup`](../mans/asl-node-lookup.md) command can also be used to query the DNS servers for information about a node.

--- a/docs/basics/incompatibles.md
+++ b/docs/basics/incompatibles.md
@@ -52,28 +52,6 @@ Check the following locations to see if your issue has already been reported:
 * [asl3-menu Issues](https://github.com/AllStarLink/asl3-menu/issues)
 * [Allmon3 Issues](https://github.com/AllStarLink/Allmon3/issues)
 
-### Issues with connections to "new" NNX Nodes
-
-There can be some confusion when first extending a node number (NNX).  Specifically, if you have/had a node that recently registered with the AllStarLink network and you expand the node number with the [Node Number Extensions (NNX)](../adv-topics/nnx.md) then some nodes may not be able to connect with your extended nodes.  Here's what happens :
-
-- You start off with a node, e.g. 63001
-    - This node registers with the AllStarLink network
-    - The ASL servers add registration info for your node (63001).  This includes updating the DNS records and node directory file (`/var/lib/asterisk/rpt_extnodes`) used by other nodes to establish connections to your node.
-
-- You extend and reconfigure your node, e.g. 63001 becomes 630010
-    - Your extended node registers with the AllStarLink network
-    - The ASL servers add registration info for your new extended node (630010).  This includes adding new DNS records and updating the node directory file.  Unfortunately, the older DNS records are not immediately removed.
-
-- Another node attempts to use a DTMF sequence to connect with your new node number.  As they enter DTMF digits their node will attempt to connect to a remote node based on the digits received.  For example, if they are trying to connect with your node, 630010, the following can happen :
-    - They have pressed the first 4 digits of the node number, 6300, their node issues a query, no match is found in the registry, and the node keeps listening
-    - They pressed the 5th digit of the node number, now 63001, their node issues a query, finds a DNS match for the pre-NNX node 63001, stops listening, and attempts to connects to the node.
-    - Everyone involved is confused about why the connection did not succeed!
-
-What happened?  Simply put, the older pre-NNX DNS records blocked the full 6-digit query and connection attempt from succeeding.  If the old records had been removed then the remote node would have kept listening for the last important digit, queried and matched the NNX node, and would have been able to successfully connect with your node.
-
-At this time, we have a once daily process that cleans out the older records.  But, you have to wait for the cleanup to happen.  We are working on changes to more quickly update the DNS records.
-
-
 ### resize2fs_once "Error"
 There are intermittent cases of errors on the screen or in  the system logs about a failure of a service named `resize2fs_once.service` after the final first boot upon installation. The error may report that it "Failed to start" or "timed out". If the `/` partition has been properly resized, which has been the case in every known
 occurrence of the error, then there is no action to take and the issue will not appear on subsequent reboots.


### PR DESCRIPTION
- Changes to the "TXT" record
- No longer active nodes are aged out (removed from DNS) after 2 hours
- INN <--> NNX changes are handled right away