### PR TITLE
HOLD UNTIL FEATURE AVAILABLE: New Docs for Authcommands feature

### DIFF
--- a/docs/adv-topics/totp-auth.md
+++ b/docs/adv-topics/totp-auth.md
@@ -1,5 +1,5 @@
-# TOTP DTMF Authentication
-TOTP DTMF Authentication allows node administrators to gate privileged DTMF commands behind a one-time password. Authorized operators authenticate over the air using a 4-digit user ID and a 6-digit code from a standard authenticator app (Google Authenticator, Authy, FreeOTP, 1Password, etc.) before gaining access to additional commands.
+# Time Based One Time Password Authentication
+TOTP Authentication allows node administrators to gate privileged DTMF commands behind a one-time password. Authorized operators authenticate over the air using a 4-digit user ID and a 6-digit code from a standard authenticator app (Google Authenticator, Authy, FreeOTP, 1Password, etc.) before gaining access to additional commands.
 
 ## How It Works
 By default, every DTMF function in `rpt.conf` is accessible to anyone who can key the radio. This feature adds an **additional, privileged command set** that becomes available only after a user authenticates.

--- a/docs/adv-topics/totp-auth.md
+++ b/docs/adv-topics/totp-auth.md
@@ -130,7 +130,7 @@ In the authenticator app, choose "manual entry" and enter:
 - Digits: 6
 - Algorithm: SHA-1
 
-**Option B — QR code (recommended):**
+**Option B — QR code:**
 
 ```bash
 # Install qrencode if needed: sudo apt install qrencode

--- a/docs/adv-topics/totp-auth.md
+++ b/docs/adv-topics/totp-auth.md
@@ -1,0 +1,222 @@
+# TOTP DTMF Authentication
+TOTP DTMF Authentication allows node administrators to gate privileged DTMF commands behind a one-time password. Authorized operators authenticate over the air using a 4-digit user ID and a 6-digit code from a standard authenticator app (Google Authenticator, Authy, FreeOTP, 1Password, etc.) before gaining access to additional commands.
+
+## How It Works
+By default, every DTMF function in `rpt.conf` is accessible to anyone who can key the radio. This feature adds an **additional, privileged command set** that becomes available only after a user authenticates.
+
+The login flow:
+
+1. User keys a DTMF login prefix followed by their 4-digit user ID and a 6-digit one-time code from their authenticator app.
+2. If the code is valid, their privileged commands become available **in addition to** the normal commands for that node.
+3. The session remains active as long as the user keeps issuing commands (sliding timeout). After a period of inactivity, the session expires automatically.
+4. The user can also log out explicitly via DTMF.
+
+Key properties:
+
+- **Per-node** — each node has its own independent session
+- **Single session** — only one user can be authenticated per node at a time
+- **Additive** — authenticated users gain extra commands; normal commands remain available to everyone
+- **Standard TOTP** — works with any RFC 6238 compatible authenticator app
+
+## Configuration
+
+### rpt.conf — Node-Level Keys
+
+Add the following keys inside your node stanza (e.g. `[1999](node-main)`):
+
+```ini
+auth_users             = /etc/asterisk/rpt_auth.conf
+auth_timeout           = 300
+auth_lockout_threshold = 5
+auth_lockout_duration  = 60
+auth_otp_step          = 30
+auth_otp_window        = 1
+```
+
+Key|Description|Default|Range
+---|-----------|-------|-----
+`auth_users`|Path to the user/secret file. **Required** to enable the feature. If omitted, auth is disabled.|*(none)*|File path
+`auth_timeout`|Sliding session timeout in seconds. Active use refreshes the timer.|300|30–86400
+`auth_lockout_threshold`|Number of failed login attempts before lockout. Set to 0 to disable lockout.|5|0–1000
+`auth_lockout_duration`|How long a locked-out user must wait, in seconds.|60|0–86400
+`auth_otp_step`|TOTP time step in seconds. Must match your authenticator app (usually 30).|30|10–120
+`auth_otp_window`|Number of time steps to accept on each side of the current step. Controls clock-skew tolerance.|1|0–3
+
+!!! note
+    Only `auth_users` is required. If it is not set or the file is missing/unreadable, the feature is silently disabled and all login attempts return an error tone.
+
+### rpt.conf — Function Table Entries
+
+The auth function must be reachable from your **default** functions stanza so that unauthenticated users can log in. Add entries for each sub-command:
+
+```ini
+[functions-main](!)
+; ... your existing entries ...
+A1 = auth,a
+A2 = auth,s
+A3 = auth,l
+```
+
+Sub-command|Parameter|Description
+-----------|---------|----------
+Login|`a`|Authenticate. Expects exactly 10 additional digits (4-digit user ID + 6-digit OTP).
+Status|`s`|Query session status. Plays a courtesy tone if a session is active.
+Logout|`l`|End the current session.
+
+!!! tip
+    The prefixes `A1`, `A2`, `A3` are examples. You can use any available DTMF prefix (e.g. `991`, `992`, `993`).
+
+### rpt.conf — Privileged Command Stanzas
+
+Define one `[functions-...]` stanza per role containing the commands available to authenticated users:
+
+```ini
+[functions-admin]
+*99 = cop,5
+*98 = cop,6
+*73 = cmd,/usr/local/bin/restart-link.sh
+
+[functions-controlop]
+*55 = cop,42
+```
+
+These stanzas use the same `prefix = action,param` syntax as any other functions stanza. They are only reachable when an authenticated user mapped to that stanza is logged in.
+
+!!! warning "Prefix Collisions"
+    If the same prefix exists in both your default functions stanza and a privileged stanza, the privileged version takes priority when a session is active. Avoid overlapping prefixes that could shadow critical default commands.
+
+### rpt_auth.conf — User and Secret File
+
+Create the user/secret file at the path specified by `auth_users`. See the full reference at [rpt_auth.conf](../config/rpt_auth_conf.md).
+
+```ini
+[users]
+1234 = JBSWY3DPEHPK3PXPABCDEFGHIJKLMNOP, functions-admin
+5678 = KRSXG5BAMFRGGZDFMZTWQ2LK, functions-controlop
+```
+
+Each line maps a 4-digit user ID to a base32 TOTP secret and a privileged stanza name.
+
+!!! warning "File Permissions"
+    This file contains shared secrets equivalent to passwords. Restrict permissions:
+
+    ```bash
+    sudo chown root:asterisk /etc/asterisk/rpt_auth.conf
+    sudo chmod 0640         /etc/asterisk/rpt_auth.conf
+    ```
+
+## Setting Up Users
+
+### Generate a Secret
+
+Generate a random 160-bit (20-byte) base32-encoded secret:
+
+```bash
+head -c 20 /dev/urandom | base32
+```
+
+This produces a string like `JBSWY3DPEHPK3PXPABCDEFGHIJKLMNOP`.
+
+### Enroll the Authenticator App
+
+**Option A — Manual entry:**
+
+In the authenticator app, choose "manual entry" and enter:
+
+- Account name: anything descriptive (e.g. `myrepeater-1234`)
+- Key: the base32 secret string
+- Type: Time-based
+- Period: 30 seconds
+- Digits: 6
+- Algorithm: SHA-1
+
+**Option B — QR code (recommended):**
+
+```bash
+# Install qrencode if needed: sudo apt install qrencode
+SECRET=JBSWY3DPEHPK3PXPABCDEFGHIJKLMNOP
+USER_ID=1234
+ISSUER=myrepeater
+
+echo "otpauth://totp/${ISSUER}:${USER_ID}?secret=${SECRET}&issuer=${ISSUER}&algorithm=SHA1&digits=6&period=30" \
+    | qrencode -t ANSIUTF8
+```
+
+Have the user scan the QR code with their authenticator app.
+
+### Add the User to rpt_auth.conf
+
+```ini
+[users]
+1234 = JBSWY3DPEHPK3PXPABCDEFGHIJKLMNOP, functions-admin
+```
+
+### Reload
+
+```bash
+asterisk -rx "module reload app_rpt.so"
+```
+
+!!! note
+    Reloading clears all active auth sessions on all nodes. Users must re-authenticate after a reload.
+
+## Day-to-Day Usage
+
+Using the example prefixes `*A1` (login), `*A2` (status), `*A3` (logout):
+
+1. Open your authenticator app and note the current 6-digit code (e.g. `849203`).
+2. Key `*A11234849203` on the radio (prefix + 4-digit user ID + 6-digit code).
+3. Listen for the courtesy tone indicating successful login.
+4. Issue privileged commands (e.g. `*99`). Each successful command refreshes the session timeout.
+5. When finished, key `*A3` to log out. (Or simply stop — the session expires after `auth_timeout` seconds of inactivity.)
+
+If the code is wrong, you will hear the standard error tone. After `auth_lockout_threshold` consecutive failures, that user ID is locked out for `auth_lockout_duration` seconds.
+
+!!! note "Security"
+    All failure modes (wrong code, locked out, feature disabled) produce identical error tones on the air. An attacker cannot distinguish between failure reasons by listening. Details are only visible in the Asterisk log and CLI.
+
+## CLI Commands
+
+Two Asterisk CLI commands are available for managing auth sessions:
+
+### Show Session Status
+
+```
+asterisk -rx "rpt auth show <node>"
+```
+
+Displays whether a session is active, which user is logged in, time remaining, failed-attempt count, and lockout status.
+
+### Force Logout
+
+```
+asterisk -rx "rpt auth logout <node>"
+```
+
+Immediately clears the active session on the specified node. Useful if a user forgets to log out or as part of an incident-response procedure.
+
+## Operational Notes
+
+- **One session per node.** If a second user logs in while a first is already authenticated, the first session is replaced without warning.
+
+- **Time sync is critical.** TOTP relies on the node's system clock. If your node's clock drifts more than `auth_otp_window × auth_otp_step` seconds from real time (default ±30 seconds), all logins will fail. Use NTP (`chrony` or `systemd-timesyncd`).
+
+- **Reloading clears sessions.** Any `module reload app_rpt.so` or rpt.conf reload clears all active auth sessions. Users must re-authenticate.
+
+- **Disabling without removing configuration.** Comment out `auth_users` in `rpt.conf` and reload. Login attempts will return error tones. The DTMF prefixes will still consume input but produce only error tones.
+
+- **Syntax errors in rpt_auth.conf.** If the file has parse errors or is unreadable, the feature is silently disabled, a warning is logged, and the node continues running normally for unauthenticated users.
+
+- **No network management interface.** Adding/removing users and rotating secrets requires editing `rpt_auth.conf` on disk and reloading. There is no network attack surface for the secret store.
+
+## Troubleshooting
+
+Symptom|Likely Cause
+-------|------------
+Every OTP attempt fails|Clock skew on the node. Check `date` vs. real time. Enable NTP.
+Specific user always fails|Wrong secret in `rpt_auth.conf` or user enrolled the wrong secret in their app. Re-generate and re-enroll.
+Login OK but privileged command still fails|Stanza name in `rpt_auth.conf` doesn't match a `[functions-...]` stanza in `rpt.conf`. Check for typos.
+All logins fail with "feature disabled" in log|`auth_users` not set, path is wrong, or file is unreadable by Asterisk. Check `ls -l` and the path.
+User locked out unexpectedly|Too many wrong codes entered. Use `rpt auth show <node>` to check. Wait for `auth_lockout_duration` to expire, or reload the module to clear.
+Authenticated command works but normal commands break|Prefix collision — your privileged stanza is shadowing a default command. Use non-overlapping prefixes.
+`module reload` doesn't pick up new users|Reload may have failed. Check the Asterisk log for parse errors in `rpt_auth.conf`.

--- a/docs/config/rpt_auth_conf.md
+++ b/docs/config/rpt_auth_conf.md
@@ -10,7 +10,7 @@ The file location is configured per-node in `rpt.conf` via the [`auth_users`](..
 
     ```bash
     sudo chown asterisk:asterisk /etc/asterisk/rpt_auth.conf
-    sudo chmod 0640          /etc/asterisk/rpt_auth.conf
+    sudo chmod 0640              /etc/asterisk/rpt_auth.conf
     ```
 
 ## Format

--- a/docs/config/rpt_auth_conf.md
+++ b/docs/config/rpt_auth_conf.md
@@ -9,7 +9,7 @@ The file location is configured per-node in `rpt.conf` via the [`auth_users`](..
     This file contains shared TOTP secrets equivalent to passwords. Restrict permissions strictly:
 
     ```bash
-    sudo chown root:asterisk /etc/asterisk/rpt_auth.conf
+    sudo chown asterisk:asterisk /etc/asterisk/rpt_auth.conf
     sudo chmod 0640          /etc/asterisk/rpt_auth.conf
     ```
 

--- a/docs/config/rpt_auth_conf.md
+++ b/docs/config/rpt_auth_conf.md
@@ -1,0 +1,54 @@
+# rpt_auth.conf
+rpt_auth.conf is the per-user TOTP authentication secrets file for [TOTP DTMF Authentication](../adv-topics/totp-auth.md). It maps 4-digit user IDs to their TOTP secrets and the privileged command stanzas they are granted access to upon login.
+
+The file location is configured per-node in `rpt.conf` via the [`auth_users`](../adv-topics/totp-auth.md#rptconf--node-level-keys) key. A common path is `/etc/asterisk/rpt_auth.conf`.
+
+## File Permissions
+
+!!! warning
+    This file contains shared TOTP secrets equivalent to passwords. Restrict permissions strictly:
+
+    ```bash
+    sudo chown root:asterisk /etc/asterisk/rpt_auth.conf
+    sudo chmod 0640         /etc/asterisk/rpt_auth.conf
+    ```
+
+## Format
+
+```ini
+[users]
+<id4> = <BASE32_SECRET>, <command_set_stanza>
+```
+
+Field|Description
+-----|----------
+`<id4>`|Exactly 4 ASCII decimal digits (e.g. `1234`). Leading zeros are significant (`0001` ≠ `1`). Must be unique within the file.
+`<BASE32_SECRET>`|RFC 4648 uppercase base32 encoded secret. Optional `=` padding. This is the same encoding used by Google Authenticator, Authy, FreeOTP, etc. Generate with: `head -c 20 /dev/urandom | base32`
+`<command_set_stanza>`|Name of a `[functions-...]` stanza in `rpt.conf` that this user is granted access to upon login. Do not include brackets.
+
+- Whitespace around commas is tolerated.
+- Lines starting with `;` are comments.
+
+## Example
+
+```ini
+[users]
+; User 1234 — admin, granted [functions-admin]
+1234 = JBSWY3DPEHPK3PXPABCDEFGHIJKLMNOP, functions-admin
+
+; User 5678 — control op, granted [functions-controlop]
+5678 = KRSXG5BAMFRGGZDFMZTWQ2LK, functions-controlop
+
+; User 9999 — read-only diagnostics, granted [functions-diag]
+9999 = NB2HI4DTHIXS653XO4XHSZLOOQ, functions-diag
+```
+
+## Notes
+
+- TOTP algorithm parameters (time step, window) are **not** per-user. They are configured per-node in `rpt.conf` via `auth_otp_step` and `auth_otp_window`.
+- If this file is missing, unreadable, or contains syntax errors, the auth feature is silently disabled and a warning is logged. The node continues to operate normally for unauthenticated users.
+- After editing this file, reload the module for changes to take effect:
+
+    ```bash
+    asterisk -rx "module reload app_rpt.so"
+    ```

--- a/docs/config/rpt_auth_conf.md
+++ b/docs/config/rpt_auth_conf.md
@@ -37,7 +37,7 @@ Field|Description
 1234 = JBSWY3DPEHPK3PXPABCDEFGHIJKLMNOP, totp-admin
 
 ; User 5678 — control op, granted totp-operator
-5678 = KRSXG5BAMFRGGZDFMZTWQ2LK, granted totp-operator
+5678 = KRSXG5BAMFRGGZDFMZTWQ2LK, totp-operator
 
 ; User 9999 — read-only diagnostics, granted totp-diag
 9999 = NB2HI4DTHIXS653XO4XHSZLO, totp-diag

--- a/docs/config/rpt_auth_conf.md
+++ b/docs/config/rpt_auth_conf.md
@@ -1,7 +1,7 @@
 # rpt_auth.conf
 rpt_auth.conf is the per-user TOTP authentication secrets file for [TOTP DTMF Authentication](../adv-topics/totp-auth.md). It maps 4-digit user IDs to their TOTP secrets and the privileged command stanzas they are granted access to upon login.
 
-The file location is configured per-node in `rpt.conf` via the [`auth_users`](../adv-topics/totp-auth.md#rptconf--node-level-keys) key. A common path is `/etc/asterisk/rpt_auth.conf`.
+The file location is configured per-node in `rpt.conf` via the [`auth_users`](../adv-topics/totp-auth.md#configuration) key. A common path is `/etc/asterisk/rpt_auth.conf`.
 
 ## File Permissions
 

--- a/docs/config/rpt_auth_conf.md
+++ b/docs/config/rpt_auth_conf.md
@@ -33,14 +33,14 @@ Field|Description
 
 ```ini
 [users]
-; User 1234 — admin, granted [functions-admin]
-1234 = JBSWY3DPEHPK3PXPABCDEFGHIJKLMNOP, functions-admin
+; User 1234 — admin, granted totp-admin
+1234 = JBSWY3DPEHPK3PXPABCDEFGHIJKLMNOP, totp-admin
 
-; User 5678 — control op, granted [functions-controlop]
-5678 = KRSXG5BAMFRGGZDFMZTWQ2LK, functions-controlop
+; User 5678 — control op, granted totp-operator
+5678 = KRSXG5BAMFRGGZDFMZTWQ2LK, granted totp-operator
 
-; User 9999 — read-only diagnostics, granted [functions-diag]
-9999 = NB2HI4DTHIXS653XO4XHSZLOOQ, functions-diag
+; User 9999 — read-only diagnostics, granted totp-diag
+9999 = NB2HI4DTHIXS653XO4XHSZLO, totp-diag
 ```
 
 ## Notes

--- a/docs/config/rpt_auth_conf.md
+++ b/docs/config/rpt_auth_conf.md
@@ -10,7 +10,7 @@ The file location is configured per-node in `rpt.conf` via the [`auth_users`](..
 
     ```bash
     sudo chown root:asterisk /etc/asterisk/rpt_auth.conf
-    sudo chmod 0640         /etc/asterisk/rpt_auth.conf
+    sudo chmod 0640          /etc/asterisk/rpt_auth.conf
     ```
 
 ## Format

--- a/docs/config/rpt_conf.md
+++ b/docs/config/rpt_conf.md
@@ -158,6 +158,25 @@ COP|Description
 64|Send pre-configured APRSTT notification, quietly (cop,64,CALL[,OVERLAYCHR]) 
 65|Send POCSAG page (equipped channel types only)
 
+### Auth Commands
+Commands using the `auth` function class provide [TOTP DTMF Authentication](../adv-topics/totp-auth.md) — per-user, one-time-password access control for privileged DTMF commands.
+
+Sample:
+
+```
+A1 = auth,a   ; Login (expects 4-digit user ID + 6-digit OTP)
+A2 = auth,s   ; Status query
+A3 = auth,l   ; Logout
+```
+
+auth|Description
+----|----------
+a|Login. Collects exactly 10 additional digits (4-digit user ID + 6-digit TOTP code) and authenticates.
+s|Status. Plays a courtesy tone indicating whether a session is active.
+l|Logout. Clears the active authentication session on this node.
+
+The auth function requires additional configuration. See [TOTP DTMF Authentication](../adv-topics/totp-auth.md) for full setup instructions and the [`rpt_auth.conf`](rpt_auth_conf.md) reference for the user/secret file format.
+
 ## General Stanza
 ASL3 introduces a new stanza in `rpt.conf`, the `[general]` stanza.
 
@@ -273,6 +292,62 @@ archiveaudio = yes                  ; enable/disable audio recordings (default =
 ```
 
 See the [Audio and Activity Logging](../adv-topics/archivedir.md) page for additional details on this feature.
+
+### auth_users=
+Path to the [rpt_auth.conf](rpt_auth_conf.md) user/secret file for [TOTP DTMF Authentication](../adv-topics/totp-auth.md). If not set or the file is unreadable, the auth feature is disabled.
+
+Sample:
+
+```
+auth_users = /etc/asterisk/rpt_auth.conf
+```
+
+### auth_timeout=
+Sliding session timeout in seconds for authenticated users. Each successful privileged command refreshes the timer. Default: `300`. Range: 30–86400.
+
+Sample:
+
+```
+auth_timeout = 300
+```
+
+### auth_lockout_threshold=
+Number of consecutive failed login attempts before a user ID is locked out. Set to `0` to disable lockout. Default: `5`. Range: 0–1000.
+
+Sample:
+
+```
+auth_lockout_threshold = 5
+```
+
+### auth_lockout_duration=
+Duration in seconds that a locked-out user must wait before attempting login again. Default: `60`. Range: 0–86400.
+
+Sample:
+
+```
+auth_lockout_duration = 60
+```
+
+### auth_otp_step=
+TOTP time step in seconds. Must match the period configured in the user's authenticator app (typically 30). Default: `30`. Range: 10–120.
+
+Sample:
+
+```
+auth_otp_step = 30
+```
+
+### auth_otp_window=
+Number of time steps to accept on each side of the current step, controlling clock-skew tolerance. With the default values (`step=30`, `window=1`), codes from ±30 seconds are accepted. Default: `1`. Range: 0–3.
+
+Sample:
+
+```
+auth_otp_window = 1
+```
+
+See [TOTP DTMF Authentication](../adv-topics/totp-auth.md) for full setup instructions.
 
 ### beaconing=
 This option, when set to `1` will send the repeater ID at the [`idtime`](#idtime) interval, regardless of whether there was repeater activity or not. This feature appears to be required in the UK, but is probably illegal in the US.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -161,6 +161,7 @@ nav:
     - adv-topics/tlb.md
     - adv-topics/tonemacros.md
     - adv-topics/tonesignalling.md
+    - adv-topics/totp-auth.md
     - adv-topics/uefi-secureboot.md
     - adv-topics/usbinterfaces.md
   - VOTER/RTCM:
@@ -208,6 +209,7 @@ nav:
     - config/extensions_conf.md
     - config/iax_conf.md
     - config/rpt_conf.md
+    - config/rpt_auth_conf.md
     - config/simpleusb_conf.md
     - config/tlb_conf.md
     - config/voter_conf.md


### PR DESCRIPTION
# Add TOTP DTMF Authentication Documentation

## Summary

Adds end-user documentation for the new per-user TOTP (Time-based One-Time Password) DTMF authentication feature in app_rpt. This feature allows node administrators to gate privileged DTMF commands behind a one-
time password verified via any standard authenticator app (Google Authenticator, Authy, FreeOTP, etc.).

## Changes

### New Pages

- **`docs/adv-topics/totp-auth.md`** — Full user guide covering:
  - Feature overview and login flow
  - Configuration (`rpt.conf` node-level keys, function table entries, privileged command stanzas)
  - Setting up users (secret generation, authenticator app enrollment via manual entry or QR code)
  - Day-to-day radio usage (login, use privileged commands, logout)
  - CLI commands (`rpt auth show`, `rpt auth logout`)
  - Operational notes (session behavior, time sync, reloads, disabling)
  - Troubleshooting table

- **`docs/config/rpt_auth_conf.md`** — Config file reference for the new `rpt_auth.conf` user/secret file (format, fields, permissions, examples)

### Updated Pages

- **`docs/config/rpt_conf.md`** — Added:
  - `auth` function class section (after COP commands) documenting the `auth,a` / `auth,s` / `auth,l` methods
  - Six new `auth_*` node-level configuration keys with descriptions, defaults, and ranges

- **`mkdocs.yml`** — Added navigation entries for both new pages (TOTP Auth under Advanced Topics, rpt_auth.conf under Config Files)

## Testing

- Verified `mkdocs build` completes without errors
- All internal cross-references resolve correctly

## Notes

- Documentation is written for end-users/node operators only; no developer internals are exposed
- Style matches existing manual conventions (admonitions, code blocks, tables, cross-references)